### PR TITLE
Pull the `DeterministicRandom` library from its repo.

### DIFF
--- a/manifest.savi
+++ b/manifest.savi
@@ -6,7 +6,7 @@
   :sources "spec/*.savi"
 
   :dependency DeterministicRandom v0
-    // TODO: :from "github:savi-lang/DeterministicRandom"
+    :from "github:savi-lang/DeterministicRandom"
     :depends on Random
 
   :dependency Spec v0


### PR DESCRIPTION
Using no `:from` clause on a dependency is deprecated,
and all standard library packages are moving to their own repos.

The only reason we didn't do this in the initial commit is
because we had to release this `Random` library first, as
`DeterministicRandom` has a dependency on `Random`.
(Note that the `Random` library only depends on `DeterministicRandom`
for its `spec` manifest, but not the real `Random` library manifest).